### PR TITLE
Deletando link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 - https://github.com/react-brasil/empresas-que-usam-react-no-brasil
 - https://github.com/GraphQLBr/empresas-que-usam-graphql-no-brasil
 - https://github.com/guru-br/catalogo_empresas
-- https://github.com/riocss/links
 - https://github.com/felipefialho/frontend-challenges
 - https://github.com/perifacode/conteudo-gratuito
 - https://github.com/leticiadasilva/por-onde-comecar


### PR DESCRIPTION
Este commit é para deletar o link da rio.css que não está participando da Hacktoberfest.